### PR TITLE
Add a near fog distance slider

### DIFF
--- a/src/main/java/jss/notfine/core/Settings.java
+++ b/src/main/java/jss/notfine/core/Settings.java
@@ -114,7 +114,8 @@ public enum Settings {
             RenderStars.reloadStarRenderList(Minecraft.getMinecraft().renderGlobal);
         }
     },
-    VOID_FOG(new NotFineOptionTickBox(false, OptionImpact.LOW));
+    VOID_FOG(new NotFineOptionTickBox(false, OptionImpact.LOW)),
+    FOG_NEAR(new NotFineOptionSliderPercentage(75, 0, 100, 1, OptionImpact.LOW));
 
     public final NotFineOption option;
 
@@ -177,6 +178,19 @@ public enum Settings {
             value = store;
             modifiedValue = store;
         }
+    }
+
+    public static class NotFineOptionSliderPercentage extends NotFineOptionSlider {
+
+        protected NotFineOptionSliderPercentage(int base, int min, int max, int step,  OptionImpact impact, OptionFlag... optionFlags) {
+            super(base, min, max, step, impact, optionFlags);
+        }
+        
+        @Override
+        public Control<Integer> getControl() {
+            return new SliderControl(this, min, max, step, NotFineControlValueFormatter.percentage());
+        }
+
     }
 
     public static class NotFineOptionTickBox extends NotFineOption<Boolean> {

--- a/src/main/java/jss/notfine/gui/NotFineGameOptionPages.java
+++ b/src/main/java/jss/notfine/gui/NotFineGameOptionPages.java
@@ -169,6 +169,7 @@ public class NotFineGameOptionPages {
             .add(Settings.MODE_CLOUD_TRANSLUCENCY.option)
             .add(Settings.MODE_STARS.option)
             .add(Settings.TOTAL_STARS.option)
+            .add(Settings.FOG_NEAR.option)
         .build());
         return new OptionPage(I18n.format("options.button.sky"), ImmutableList.copyOf(groups));
     }

--- a/src/main/java/jss/notfine/gui/options/control/NotFineControlValueFormatter.java
+++ b/src/main/java/jss/notfine/gui/options/control/NotFineControlValueFormatter.java
@@ -4,12 +4,17 @@ import me.jellysquid.mods.sodium.client.gui.options.control.ControlValueFormatte
 import net.minecraft.client.resources.I18n;
 
 public class NotFineControlValueFormatter {
+
     public static ControlValueFormatter multiplied(float multiplier) {
         return (value) -> String.valueOf((value * multiplier));
     }
 
     public static ControlValueFormatter powerOfTwo() {
         return (v) -> (v == 0) ? I18n.format("options.off") : I18n.format((int)Math.pow(2, v) + "x");
+    }
+
+    public static ControlValueFormatter percentage() {
+        return (value) -> String.valueOf(value) + "%";
     }
 
 }

--- a/src/main/java/jss/notfine/mixins/early/minecraft/toggle/MixinEntityRenderer.java
+++ b/src/main/java/jss/notfine/mixins/early/minecraft/toggle/MixinEntityRenderer.java
@@ -14,6 +14,8 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
+import org.lwjgl.opengl.GL11;
+
 @Mixin(EntityRenderer.class)
 abstract public class MixinEntityRenderer {
 
@@ -46,6 +48,18 @@ abstract public class MixinEntityRenderer {
     }
 
     @Redirect(
+        method = "setupFog",
+        at = @At(
+            value = "INVOKE",
+            target = "Lorg/lwjgl/opengl/GL11;glFogf(IF)V",
+            ordinal = 14
+        )
+    )
+    private void notFineGlFogF(int mode, float value) {
+        GL11.glFogf(mode, farPlaneDistance * (int)Settings.FOG_NEAR.option.getStore() * 0.01F - 1F);
+    }
+
+    @Redirect(
         method = "updateRenderer()V",
         at = @At(
             value = "INVOKE",
@@ -63,6 +77,10 @@ abstract public class MixinEntityRenderer {
     @Shadow
     abstract void updateTorchFlicker();
 
-    @Shadow private boolean lightmapUpdateNeeded;
+    @Shadow
+    private boolean lightmapUpdateNeeded;
+
+    @Shadow
+    private float farPlaneDistance;
 
 }

--- a/src/main/resources/assets/notfine/lang/en_US.lang
+++ b/src/main/resources/assets/notfine/lang/en_US.lang
@@ -40,3 +40,4 @@ options.title.sky=Atmosphere Settings
 options.title.video=Video Settings
 options.total_stars=Star Density
 options.void_fog=Void Fog
+options.fog_near=Near Fog Distance


### PR DESCRIPTION
This PR adds a new option under _Video Settings > Atmosphere_ to allow the player to configure what percentage of the far plane the near fog plane should start at. By default, this is set to 75%, which is Mojang's default.

This is an option that is present in OptiFine, and reducing the near fog distance can vastly improve the sense of depth at high render distances; reducing the "San Andreas Remastered" effect that causes worlds to feel much smaller than they otherwise should.